### PR TITLE
Fehlerhaften aktiven DB-Pfad in get_db und create_app korrekt behandeln

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -115,6 +115,11 @@ def create_app():
         aktive_datenbank = registry.get_active_db_path()
         if aktive_datenbank and Path(aktive_datenbank).exists():
             return aktive_datenbank
+        if aktive_datenbank:
+            app.logger.warning(
+                "Gespeicherter DB-Pfad ist ungueltig und wird ignoriert: %s",
+                aktive_datenbank,
+            )
 
         aktuelle_jahres_db = registry.find_latest_db_for_year(datetime.now().year)
         if aktuelle_jahres_db:
@@ -159,6 +164,12 @@ def get_db():
         aktive_datenbank = registry.get_active_db_path()
         datenbankpfad = aktive_datenbank
         if (not datenbankpfad or not Path(datenbankpfad).exists()):
+            if aktive_datenbank:
+                current_app.logger.warning(
+                    "Gespeicherter DB-Pfad ist ungueltig und wird ignoriert: %s",
+                    aktive_datenbank,
+                )
+            datenbankpfad = None
             aktuelle_jahres_db = registry.find_latest_db_for_year(datetime.now().year)
             if aktuelle_jahres_db:
                 registry.set_active_db_path(aktuelle_jahres_db.path)


### PR DESCRIPTION
### Motivation
- Verhindern, dass bei einem gespeicherten, aber nicht vorhandenen DB-Pfad eine `Database`-Instanz mit einem ungültigen Pfad erzeugt wird.
- Klar sichtbar machen, wenn ein gespeicherter aktiver DB-Pfad nicht mehr existiert, damit das Problem im Log auffällt.
- Einheitliches Verhalten zwischen der App-Factory-Variante (`_resolve_active_db_path`) und der modulweiten `get_db()`-Funktion sicherstellen.

### Description
- In `app/__init__.py` wird in der modulweiten `get_db()`-Funktion der gespeicherte Pfad geprüft und bei Ungültigkeit explizit auf `None` gesetzt, bevor auf die aktuelle Jahres-DB gefallbackt wird.
- Es wird nur dann `registry.set_active_db_path(...)` und `datenbankpfad = aktuelle_jahres_db.path` gesetzt, wenn tatsächlich eine `aktuelle_jahres_db` gefunden wurde.
- Die Zuweisung `g.db = Database(path=datenbankpfad) if datenbankpfad else None` bleibt bestehen, verhindert aber nun durch obige Änderung eine Initialisierung mit einem ungültigen Pfad.
- Warn-Logs wurden ergänzt, wenn `registry.get_active_db_path()` einen ungültigen Pfad liefert, sowohl in `_resolve_active_db_path()` innerhalb von `create_app()` als auch in der modulweiten `get_db()`; die Änderungen betreffen `app/__init__.py`.

### Testing
- `python -m py_compile app/__init__.py` ausgeführt und erfolgreich durchgelaufen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c655351e50832f95e79e450ecd76a1)